### PR TITLE
Android: Detect keystrokes on modal dialogs

### DIFF
--- a/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/devsupport/RNActivityDelegate.java
+++ b/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/devsupport/RNActivityDelegate.java
@@ -1,16 +1,12 @@
 package com.mediamonks.rnnativenavigation.devsupport;
 
-import android.app.Activity;
-import android.content.Context;
 import android.os.Bundle;
-import android.support.v4.app.FragmentActivity;
 import android.view.KeyEvent;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactFragmentActivity;
 import com.mediamonks.rnnativenavigation.bridge.RNNativeNavigationModule;
-import com.mediamonks.rnnativenavigation.bridge.RNNativeNavigationPackage;
 
 import javax.annotation.Nullable;
 
@@ -38,20 +34,12 @@ public class RNActivityDelegate extends ReactActivityDelegate {
     @Override public boolean onKeyUp(int keyCode, KeyEvent event) {
         if (getReactNativeHost().hasInstance() && getReactNativeHost().getUseDeveloperSupport()) {
             boolean didDoubleTapE = Assertions.assertNotNull(_doubleTapResetRecognizer)
-                    .didDoubleTapE(keyCode, getPlainActivity().getCurrentFocus());
+                    .didDoubleTapE(keyCode, _activity.getCurrentFocus());
             if (didDoubleTapE) {
                 getReactInstanceManager().getCurrentReactContext().getNativeModule(RNNativeNavigationModule.class).resetNavigation();
             }
         }
 
         return super.onKeyUp(keyCode, event);
-    }
-
-    private Context getContext() {
-        return Assertions.assertNotNull(_activity);
-    }
-
-    private Activity getPlainActivity() {
-        return ((Activity) getContext());
     }
 }

--- a/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
+++ b/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
@@ -31,6 +31,9 @@ public class ModalFragment extends DialogFragment implements RNNNFragment {
     private View.OnKeyListener _forwardKeyListener = new View.OnKeyListener() {
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
+            if (event.getAction() != KeyEvent.ACTION_UP) {
+                return false;
+            }
             switch (keyCode) {
                 // Ignore all these keys, as they are the ones that PhoneWindow cares about
                 case KeyEvent.KEYCODE_VOLUME_UP:

--- a/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
+++ b/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
@@ -107,6 +107,24 @@ public class ModalFragment extends DialogFragment implements RNNNFragment {
     }
 
     @Override
+    public void onStart() {
+        super.onStart();
+
+        Assertions.assertNotNull(getView())
+                .getViewTreeObserver()
+                .addOnGlobalFocusChangeListener(_globalFocusChangeListener);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+
+        Assertions.assertNotNull(getView())
+                .getViewTreeObserver()
+                .removeOnGlobalFocusChangeListener(_globalFocusChangeListener);
+    }
+
+    @Override
     public void onDismiss(DialogInterface dialog) {
         super.onDismiss(dialog);
 

--- a/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
+++ b/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
@@ -14,6 +14,7 @@ import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
+import com.facebook.infer.annotation.Assertions;
 import com.mediamonks.rnnativenavigation.R;
 import com.mediamonks.rnnativenavigation.data.Node;
 
@@ -58,6 +59,20 @@ public class ModalFragment extends DialogFragment implements RNNNFragment {
         }
     };
 
+    private ViewTreeObserver.OnGlobalFocusChangeListener _globalFocusChangeListener = new ViewTreeObserver.OnGlobalFocusChangeListener() {
+        @Override
+        public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+            if (oldFocus != null) {
+                oldFocus.setOnKeyListener(null);
+            }
+            if (newFocus != null) {
+                // DialogsFragment views don't bubble alphanumeric key events up to the containing Activity, because their containing PhoneVWindow discards them.
+                // Here we forward them forcefully in order to allow development shortcuts on the emulator
+                newFocus.setOnKeyListener(_forwardKeyListener);
+            }
+        }
+    };
+
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
@@ -77,19 +92,6 @@ public class ModalFragment extends DialogFragment implements RNNNFragment {
         view.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         View.generateViewId();
         view.setId(View.generateViewId());
-
-        ViewTreeObserver viewTreeObserver = view.getViewTreeObserver();
-        viewTreeObserver.addOnGlobalFocusChangeListener(new ViewTreeObserver.OnGlobalFocusChangeListener() {
-            @Override
-            public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-                if (newFocus != null) {
-                    // DialogsFragment views don't bubble alphanumeric key events up to the containing Activity, because their containing PhoneVWindow discards them.
-                    // Here we forward them forcefully in order to allow development shortcuts on the emulator
-                    newFocus.setOnKeyListener(_forwardKeyListener);
-                }
-            }
-        });
-
         return view;
     }
 

--- a/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
+++ b/native-navigation/android/src/main/java/com/mediamonks/rnnativenavigation/factory/ModalFragment.java
@@ -102,7 +102,7 @@ public class ModalFragment extends DialogFragment implements RNNNFragment {
         FragmentManager fragmentManager = getChildFragmentManager();
         FragmentTransaction transaction = fragmentManager.beginTransaction();
         _fragment = getNode().generateFragment();
-        transaction.add(getView().getId(), _fragment);
+        transaction.add(view.getId(), _fragment);
         transaction.commitNowAllowingStateLoss();
     }
 


### PR DESCRIPTION
Pull request for #5 

Views in ModalFragment don't forward alphanumeric key events to the containing Activity because one of its intermediate containers, PhoneWindow, deliberately ignores them.

To deal with this, the idea is to put an OnKeyListener on the ModalFragment's View as soon as it is created, however that does not work because that View is just the container for the actual modal dialog content, which has not been added by this time.

To deal with that, we listen for focus changes within the container view by using OnGlobalFocusChangeListener, and whenever there is a focus change, we add the OnKeyListener on the newly focused View (which is the one that will receive our keystrokes).

To assign the same OnKeyListener, maybe many times, to the same View may not be very elegant, but it should be harmless.